### PR TITLE
Transform image into duotone

### DIFF
--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -9,6 +9,7 @@ window.onload = function(){
 
   var imageData = ctx.getImageData(0, 0, img.width, img.height);
   var data = imageData.data;
+  var pixelCount = canvas.width * canvas.height;
 
   // Color as array for rgb values
   // TODO: generate this array from an rgba color
@@ -20,20 +21,17 @@ window.onload = function(){
   // based on pixel luminence.
   var gradientArray = createGradient(green, red);
 
-  var duoToneData =  convertToDuoTone(data, gradientArray);
+  var duoToneData =  convertToDuoTone(data, pixelCount, gradientArray);
   var imageData = new ImageData(new Uint8ClampedArray(duoToneData), canvas.width, canvas.height);
 
   ctx.putImageData(imageData, 0, 0);
 };
 
-function convertToDuoTone(imageData, gradientArray) {
+function convertToDuoTone(imageData, pixelCount, gradientArray) {
   var pixels = imageData;
-  var canvas = document.getElementById('canvas');
-
-  var pixelCount = canvas.width * canvas.height;
   var pixelArray = [];
 
-  convertImageToGrayscale(imageData);
+  convertImageToGrayscale(pixels);
 
   for (var i = 0; i < pixelCount; i++) {
     var offset, r, g, b, a;

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -24,24 +24,32 @@ window.onload = function(){
       data[p] = data[p+1] = data[p+2] = avg;
   }
 
-  // Create a gradient from which to pick colors from the duotone
-  // based on pixel luminence.
-  var gradientArray = [];
   // Color as array for rgb values
+  // TODO: generate this array from an rgba color
+  // to allow more flexibility on input here
   var green = [80, 254, 16];
   var red = [254, 16, 16];
 
-  // arbitrarily choosing a gradient of 255 values for each
-  for (var d = 0; d < 255; d += 1) {
-    var ratio = d / 255;
-    var l = ratio;
-    var rA = Math.floor(green[0] * l + green[0] * (1 - l));
-    var gA = Math.floor(green[1] * l + green[1] * (1 - l));
-    var bA = Math.floor(green[2] * l + green[2] * (1 - l));
-    gradientArray.push([rA, gA, bA]);
-  }
+  // Create a gradient from which to pick colors from the duotone
+  // based on pixel luminence.
+  var gradientArray = createGradient(green, red);
 
   console.log(gradientArray)
 
   ctx.putImageData(imageData, 0, 0);
 };
+
+function createGradient(color1, color2) {
+  var gradient = [];
+
+  for (i = 0; i < 255; i += 1) {
+    var ratio = i / 255;
+    var l = ratio;
+    var r = Math.floor(color1[0] * l + color2[0] * (1 - l));
+    var g = Math.floor(color1[1] * l + color2[1] * (1 - l));
+    var b = Math.floor(color1[2] * l + color2[2] * (1 - l));
+    gradient.push([r, g, b]);
+  }
+
+  return gradient;
+}

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -12,17 +12,7 @@ window.onload = function(){
 
   var data = imageData.data;
 
-  // Convert the image to grayscale
-  var r,g,b,avg;
-  for(var p = 0, len = data.length; p < len; p+=4) {
-      r = data[p]
-      g = data[p+1];
-      b = data[p+2];
-
-      avg = Math.floor((r+g+b)/3);
-
-      data[p] = data[p+1] = data[p+2] = avg;
-  }
+  convertImageToGrayscale(data);
 
   // Color as array for rgb values
   // TODO: generate this array from an rgba color
@@ -39,6 +29,20 @@ window.onload = function(){
   ctx.putImageData(imageData, 0, 0);
 };
 
+function convertImageToGrayscale(imageData) {
+  var r, g, b, avg;
+
+  for(var pixel = 0, len = imageData.length; pixel < len; pixel += 4) {
+    r = imageData[pixel]
+    g = imageData[pixel + 1];
+    b = imageData[pixel + 2];
+
+    avg = Math.floor((r + g + b) / 3);
+
+    imageData[pixel] = imageData[pixel + 1] = imageData[pixel + 2] = avg;
+  }
+};
+
 function createGradient(color1, color2) {
   var gradient = [];
 
@@ -49,7 +53,7 @@ function createGradient(color1, color2) {
     var g = Math.floor(color1[1] * l + color2[1] * (1 - l));
     var b = Math.floor(color1[2] * l + color2[2] * (1 - l));
     gradient.push([r, g, b]);
-  }
+  };
 
   return gradient;
-}
+};

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -24,5 +24,24 @@ window.onload = function(){
       data[p] = data[p+1] = data[p+2] = avg;
   }
 
+  // Create a gradient from which to pick colors from the duotone
+  // based on pixel luminence.
+  var gradientArray = [];
+  // Color as array for rgb values
+  var green = [80, 254, 16];
+  var red = [254, 16, 16];
+
+  // arbitrarily choosing a gradient of 255 values for each
+  for (var d = 0; d < 255; d += 1) {
+    var ratio = d / 255;
+    var l = ratio;
+    var rA = Math.floor(green[0] * l + green[0] * (1 - l));
+    var gA = Math.floor(green[1] * l + green[1] * (1 - l));
+    var bA = Math.floor(green[2] * l + green[2] * (1 - l));
+    gradientArray.push([rA, gA, bA]);
+  }
+
+  console.log(gradientArray)
+
   ctx.putImageData(imageData, 0, 0);
 };

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -6,4 +6,23 @@ window.onload = function(){
   canvas.width = img.width;
   canvas.height = img.height;
   ctx.drawImage(img, 0, 0, img.width, img.height);
+
+  var imageData = ctx.getImageData(0, 0, img.width, img.height);
+  console.log(imageData)
+
+  var data = imageData.data;
+
+  // Convert the image to grayscale
+  var r,g,b,avg;
+  for(var p = 0, len = data.length; p < len; p+=4) {
+      r = data[p]
+      g = data[p+1];
+      b = data[p+2];
+
+      avg = Math.floor((r+g+b)/3);
+
+      data[p] = data[p+1] = data[p+2] = avg;
+  }
+
+  ctx.putImageData(imageData, 0, 0);
 };


### PR DESCRIPTION
This PR adds functionality to transform the image data into a duotone of two colors based upon the pixel's brightness.

Notes: 
- The calculation for pixel brightness was taken from [w3.org](https://www.w3.org/TR/AERT#color-contrast)
- Needing to convert the rgba value to HSL, I found [this on stackoverflow](https://stackoverflow.com/questions/2353211/hsl-to-rgb-color-conversion). Further SO answers & miscellaneous blog posts all seem to use a copy and paste version of this code. I think it's fine for now, but if we were to move to doing more image manipulations, I would prefer to abstract out color conversions with a library (maybe [this](https://github.com/bgrins/TinyColor) or [this](https://github.com/Qix-/color)) to make this easier to follow and all around more pleasant to develop with.


Before:
![screen shot 2017-08-02 at 18 02 04](https://user-images.githubusercontent.com/4978498/28901412-b9b6b838-77ac-11e7-8f93-b983fc83ea1b.png)



After:


![screen shot 2017-08-02 at 18 01 46](https://user-images.githubusercontent.com/4978498/28901413-bc8f2c16-77ac-11e7-9d6d-925418784cc4.png)